### PR TITLE
docs(md-toolbar-tools-bottom): remove undefined class

### DIFF
--- a/src/components/toolbar/demoBasicUsage/index.html
+++ b/src/components/toolbar/demoBasicUsage/index.html
@@ -55,7 +55,7 @@
 
     <md-toolbar class="md-tall md-warn md-hue-3">
       <span flex></span>
-      <h2 class="md-toolbar-tools md-toolbar-tools-bottom">
+      <h2 class="md-toolbar-tools">
         <span class="md-flex">Toolbar: tall with actions pin to the bottom (md-warn md-hue-3)</span>
       </h2>
     </md-toolbar>


### PR DESCRIPTION
Remove undefined "md-toolbar-tools-bottom" class from the example code in the documentation to avoid confusion (the class is not defined anywhere in the repo).
